### PR TITLE
Refactor Mako actions, fix setup-git command & add exec-ryujinx-tasks command

### DIFF
--- a/.github/actions/execute-command/README.md
+++ b/.github/actions/execute-command/README.md
@@ -1,0 +1,20 @@
+# execute-command
+
+A small composite action to run the specified Mako subcommand.
+
+## Usage
+
+Add the following step to your workflow:
+
+```yml
+- name: Execute Ryujinx-Mako command
+  uses: Ryujinx/Ryujinx-Mako/.github/actions/execute-command@master
+  with:
+    command: "<a valid subcommand for Mako>"
+    args: "<subcommand args>"
+    app_id: ${{ secrets.MAKO_APP_ID }}
+    private_key: ${{ secrets.MAKO_PRIVATE_KEY }}
+    installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}
+```
+
+

--- a/.github/actions/execute-command/action.yml
+++ b/.github/actions/execute-command/action.yml
@@ -1,0 +1,29 @@
+name: 'Mako command'
+description: 'Execute a Mako subcommand'
+inputs:
+  command:
+    description: 'Subcommand to execute with Mako'
+    required: true
+  args:
+    description: 'Arguments for the specified subcommand'
+    required: true
+    default: ''
+  app_id:
+    description: 'GitHub App ID'
+    required: true
+  private_key:
+    description: 'Private key for the GitHub App'
+    required: true
+  installation_id:
+    description: 'GitHub App Installation ID'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        poetry -n -C "${{ github.action_path }}../" run ryujinx-mako ${{ inputs.command }} ${{ inputs.args }}
+      shell: bash
+      env:
+        MAKO_APP_ID: ${{ inputs.app_id }}
+        MAKO_PRIVATE_KEY: ${{ inputs.private_key }}
+        MAKO_INSTALLATION_ID: ${{ inputs.installation_id }}

--- a/.github/actions/execute-command/action.yml
+++ b/.github/actions/execute-command/action.yml
@@ -20,8 +20,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Get Mako path
+      id: path
+      run: |
+        echo "mako=$(realpath '${{ github.action_path }}/../../../')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - run: |
-        poetry -n -C "${{ github.action_path }}" run ryujinx-mako ${{ inputs.command }} ${{ inputs.args }}
+        poetry -n -C "${{ steps.path.outputs.mako }}" run ryujinx-mako ${{ inputs.command }} ${{ inputs.args }}
       shell: bash
       env:
         MAKO_APP_ID: ${{ inputs.app_id }}

--- a/.github/actions/execute-command/action.yml
+++ b/.github/actions/execute-command/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        poetry -n -C "${{ github.action_path }}../" run ryujinx-mako ${{ inputs.command }} ${{ inputs.args }}
+        poetry -n -C "${{ github.action_path }}" run ryujinx-mako ${{ inputs.command }} ${{ inputs.args }}
       shell: bash
       env:
         MAKO_APP_ID: ${{ inputs.app_id }}

--- a/.github/actions/setup-mako/README.md
+++ b/.github/actions/setup-mako/README.md
@@ -6,18 +6,11 @@ It installs poetry and all module dependencies.
 
 ## Usage
 
-Add the following steps to your workflow:
+Add the following step to your workflow:
 
 ```yml
-- name: Checkout Ryujinx-Mako
-  uses: actions/checkout@v3
-  with:
-    repository: Ryujinx/Ryujinx-Mako
-    ref: master
-    path: ".ryujinx-mako"
-
 - name: Setup Ryujinx-Mako
-  uses: .ryujinx-mako/.github/actions/setup-mako
+  uses: Ryujinx/Ryujinx-Mako/.github/actions/setup-mako@master
 ```
 
 

--- a/.github/actions/setup-mako/action.yml
+++ b/.github/actions/setup-mako/action.yml
@@ -3,10 +3,16 @@ description: 'Setup the environment for Mako'
 runs:
   using: 'composite'
   steps:
+    - name: Get Mako path
+      id: path
+      run: |
+        echo "mako=$(realpath '${{ github.action_path }}/../../../')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - run: pipx install poetry
       shell: bash
 
     - run: |
-        cd "${{ github.action_path }}/../"
+        cd "${{ steps.path.outputs.mako }}"
         poetry install --only main
       shell: bash

--- a/.github/actions/setup-mako/action.yml
+++ b/.github/actions/setup-mako/action.yml
@@ -1,5 +1,5 @@
-name: 'Setup Ryujinx-Mako'
-description: 'Setup the environment for Ryujinx-Mako'
+name: 'Setup Mako'
+description: 'Setup the environment for Mako'
 runs:
   using: 'composite'
   steps:
@@ -7,6 +7,6 @@ runs:
       shell: bash
 
     - run: |
-        cd .ryujinx-mako
+        cd "${{ github.action_path }}/../"
         poetry install --only main
       shell: bash

--- a/.github/actions/setup-mako/action.yml
+++ b/.github/actions/setup-mako/action.yml
@@ -9,7 +9,21 @@ runs:
         echo "mako=$(realpath '${{ github.action_path }}/../../../')" >> $GITHUB_OUTPUT
       shell: bash
 
-    - run: pipx install poetry
+    - uses: actions/setup-python@v4
+      with:
+        cache: 'poetry'
+
+    - name: Ensure pipx is available
+      run: |
+        if ! command -v pipx > /dev/null 2>&1; then
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        python3 -m pip install --user pipx
+        python3 -m pipx ensurepath
+        fi
+      shell: bash
+
+    - name: Install poetry
+      run: pipx install poetry
       shell: bash
 
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test Ryujinx-Mako (setup-git)
+        uses: ./
+        with:
+          command: setup-git
+          app_id: ${{ secrets.MAKO_APP_ID }}
+          private_key: ${{ secrets.MAKO_PRIVATE_KEY }}
+          installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}
+
+  subactions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test setup-mako
+        uses: ./.github/actions/setup-mako
+
+      - name: Test execute-command (setup-git)
+        uses: ./.github/actions/execute-command
+        with:
+          command: setup-git
+          app_id: ${{ secrets.MAKO_APP_ID }}
+          private_key: ${{ secrets.MAKO_PRIVATE_KEY }}
+          installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ options:
   -h, --help            show this help message and exit
 
 subcommands:
-  setup-git             Set git identity to Ryujinx-Mako
-  
-  update-reviewers      Update reviewers for the specified PR
+  {setup-git,update-reviewers}
+    setup-git           Configure git identity for Ryujinx-Mako
+    update-reviewers    Update reviewers for the specified PR
 ```
 
 ### setup-git
@@ -38,11 +38,11 @@ subcommands:
 ```
 usage: ryujinx_mako setup-git [-h] [-l]
 
-Set git identity to Ryujinx-Mako
+Configure git identity for Ryujinx-Mako
 
 options:
   -h, --help   show this help message and exit
-  -l, --local  Set git identity only for the current repository.
+  -l, --local  configure the git identity only for the current repository
 ```
 
 ### update-reviewers
@@ -53,9 +53,9 @@ usage: ryujinx_mako update-reviewers [-h] repo_path pr_number config_path
 Update reviewers for the specified PR
 
 positional arguments:
-  repo_path
-  pr_number
-  config_path
+  repo_path    full name of the GitHub repository (format: OWNER/REPO)
+  pr_number    the number of the pull request to check
+  config_path  the path to the reviewers config file
 
 options:
   -h, --help   show this help message and exit

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the following step to your workflow:
 ## Available commands
 
 ```
-usage: ryujinx_mako [-h] {setup-git,update-reviewers} ...
+usage: ryujinx_mako [-h] {setup-git,update-reviewers,exec-ryujinx-tasks} ...
 
 A python module to aid Ryujinx with project management and moderation
 
@@ -34,9 +34,10 @@ options:
   -h, --help            show this help message and exit
 
 subcommands:
-  {setup-git,update-reviewers}
+  {setup-git,update-reviewers,exec-ryujinx-tasks}
     setup-git           Configure git identity for Ryujinx-Mako
     update-reviewers    Update reviewers for the specified PR
+    exec-ryujinx-tasks  Execute all Ryujinx tasks for a specific event
 ```
 
 ### setup-git
@@ -65,4 +66,29 @@ positional arguments:
 
 options:
   -h, --help   show this help message and exit
+```
+
+### exec-ryujinx-tasks
+
+```
+usage: ryujinx_mako exec-ryujinx-tasks [-h] --event-name EVENT_NAME
+                                       --event-path EVENT_PATH [-w WORKSPACE]
+                                       repo_path run_id
+
+Execute all Ryujinx tasks for a specific event
+
+positional arguments:
+  repo_path             full name of the GitHub repository (format:
+                        OWNER/REPO)
+  run_id                The unique identifier of the workflow run
+
+options:
+  -h, --help            show this help message and exit
+  --event-name EVENT_NAME
+                        the name of the event that triggered the workflow run
+  --event-path EVENT_PATH
+                        the path to the file on the runner that contains the
+                        full event webhook payload
+  -w WORKSPACE, --workspace WORKSPACE
+                        the working directory on the runner
 ```

--- a/README.md
+++ b/README.md
@@ -4,33 +4,18 @@ A custom GitHub App to aid Ryujinx with project management and moderation
 
 ## Usage
 
-1. Add the following steps to your workflow:
+Add the following step to your workflow:
 
-   ```yml
-   - name: Checkout Ryujinx-Mako
-     uses: actions/checkout@v3
-     with:
-       repository: Ryujinx/Ryujinx-Mako
-       ref: master
-       path: '.ryujinx-mako'
-   
-   - name: Setup Ryujinx-Mako
-     uses: ./.ryujinx-mako/.github/actions/setup-mako
-   ```
-   
-2. Execute the available commands like this:
-    
-   ```yml
-   - name: Setup git identity for Ryujinx-Mako
-     run: |
-        # poetry -n -C .ryujinx-mako run ryujinx-mako <command> [<args>]
-        # for example:
-        poetry -n -C .ryujinx-mako run ryujinx-mako setup-git
-     env:
-       MAKO_APP_ID: ${{ secrets.MAKO_APP_ID }}
-       MAKO_PRIVATE_KEY: ${{ secrets.MAKO_PRIVATE_KEY }}
-       MAKO_INSTALLATION_ID: ${{ secrets.MAKO_INSTALLATION_ID }}
-   ```
+```yml
+- name: Run Ryujinx-Mako
+  uses: Ryujinx/Ryujinx-Mako@master
+  with:
+    command: <Mako subcommand>
+    args: <subcommand args>
+    app_id: ${{ secrets.MAKO_APP_ID }}
+    private_key: ${{ secrets.MAKO_PRIVATE_KEY }}
+    installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}
+```
 
 ## Available commands
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Add the following step to your workflow:
     installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}
 ```
 
+## Required environment variables
+
+- `MAKO_APP_ID`: the GitHub App ID
+- `MAKO_PRIVATE_KEY`: the contents of the GitHub App private key
+- `MAKO_INSTALLATION_ID`: the GitHub App installation ID
+
 ## Available commands
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -29,11 +29,11 @@ runs:
       shell: bash
 
     - name: Setup Mako
-      if: steps.check_dest.outputs.exists == "false"
+      if: steps.check_dest.outputs.exists == 'false'
       uses: ./.github/actions/setup-mako
 
     - name: Create setup finished flag
-      if: steps.check_dest.outputs.exists == "false"
+      if: steps.check_dest.outputs.exists == 'false'
       run: touch "${{ github.action_path }}/.ryujinx-mako_setup-done"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,47 @@
+name: 'Run Ryujinx-Mako'
+description: 'Setup Mako and execute the specified subcommand'
+inputs:
+  command:
+    description: 'Subcommand to execute with Mako'
+    required: true
+  args:
+    description: 'Arguments for the specified subcommand'
+    required: true
+    default: ''
+  app_id:
+    description: 'GitHub App ID'
+    required: true
+  private_key:
+    description: 'Private key for the GitHub App'
+    required: true
+  installation_id:
+    description: 'GitHub App Installation ID'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if Mako was already setup
+      id: check_dest
+      run: |
+        [ -f "${{ github.action_path }}/.ryujinx-mako_setup-done" ] \
+        && echo "exists=true" >> $GITHUB_OUTPUT \
+        || echo "exists=false" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Setup Mako
+      if: steps.check_dest.outputs.exists == "false"
+      uses: ./.github/actions/setup-mako
+
+    - name: Create setup finished flag
+      if: steps.check_dest.outputs.exists == "false"
+      run: touch "${{ github.action_path }}/.ryujinx-mako_setup-done"
+      shell: bash
+
+    - name: Run Mako subcommand
+      uses: ./.github/actions/execute-command
+      with:
+        command: ${{ inputs.command }}
+        args: ${{ inputs.args }}
+        app_id: ${{ inputs.app_id }}
+        private_key: ${{ inputs.private_key }}
+        installation_id: ${{ inputs.installation_id }}

--- a/ryujinx_mako/__main__.py
+++ b/ryujinx_mako/__main__.py
@@ -3,6 +3,7 @@ import logging
 
 from ryujinx_mako import commands
 from ryujinx_mako._const import SCRIPT_NAME
+from ryujinx_mako.commands import Subcommand
 
 parser = argparse.ArgumentParser(
     prog=SCRIPT_NAME,
@@ -21,8 +22,9 @@ for subcommand in commands.SUBCOMMANDS:
         description=subcommand.description(),
         add_help=True,
     )
+    Subcommand.add_subcommand(subcommand.name(), subcommand(subcommand_parser))
     # Keep a reference to the subcommand
-    subcommands.append(subcommand(subcommand_parser))
+    subcommands.append(Subcommand.get_subcommand(subcommand.name()))
 
 
 def run():

--- a/ryujinx_mako/__main__.py
+++ b/ryujinx_mako/__main__.py
@@ -20,7 +20,7 @@ for subcommand in commands.SUBCOMMANDS:
     subcommand_parser = subparsers.add_parser(
         subcommand.name(),
         description=subcommand.description(),
-        add_help=True,
+        help=subcommand.description(),
     )
     Subcommand.add_subcommand(subcommand.name(), subcommand(subcommand_parser))
     # Keep a reference to the subcommand

--- a/ryujinx_mako/_const.py
+++ b/ryujinx_mako/_const.py
@@ -11,6 +11,7 @@ except ImportError:
 
 
 class ConfigKey(StrEnum):
+    DryRun = "MAKO_DRY_RUN"
     AppID = "MAKO_APP_ID"
     PrivateKey = "MAKO_PRIVATE_KEY"
     InstallationID = "MAKO_INSTALLATION_ID"
@@ -19,14 +20,23 @@ class ConfigKey(StrEnum):
 NAME = "Ryujinx-Mako"
 SCRIPT_NAME = NAME.lower().replace("-", "_")
 
-# Check environment variables
-for key in ConfigKey:
-    if key not in os.environ.keys() or len(os.environ[key]) == 0:
-        raise KeyError(f"Required environment variable not set: {key}")
+if ConfigKey.DryRun not in os.environ.keys() or len(os.environ[ConfigKey.DryRun]) == 0:
+    IS_DRY_RUN = False
+    # Check environment variables
+    for key in ConfigKey:
+        if key == ConfigKey.DryRun:
+            continue
+        if key not in os.environ.keys() or len(os.environ[key]) == 0:
+            raise KeyError(f"Required environment variable not set: {key}")
 
-APP_ID = int(os.environ[ConfigKey.AppID])
-PRIVATE_KEY = os.environ[ConfigKey.PrivateKey]
-INSTALLATION_ID = int(os.environ[ConfigKey.InstallationID])
+    APP_ID = int(os.environ[ConfigKey.AppID])
+    PRIVATE_KEY = os.environ[ConfigKey.PrivateKey]
+    INSTALLATION_ID = int(os.environ[ConfigKey.InstallationID])
+else:
+    IS_DRY_RUN = True
+    APP_ID = 0
+    PRIVATE_KEY = ""
+    INSTALLATION_ID = 0
 
 GH_BOT_SUFFIX = "[bot]"
 GH_EMAIL_TEMPLATE = "{user_id}+{username}@users.noreply.github.com"

--- a/ryujinx_mako/_const.py
+++ b/ryujinx_mako/_const.py
@@ -21,7 +21,7 @@ SCRIPT_NAME = NAME.lower().replace("-", "_")
 
 # Check environment variables
 for key in ConfigKey:
-    if key not in os.environ.keys():
+    if key not in os.environ.keys() or len(os.environ[key]) == 0:
         raise KeyError(f"Required environment variable not set: {key}")
 
 APP_ID = int(os.environ[ConfigKey.AppID])

--- a/ryujinx_mako/commands/__init__.py
+++ b/ryujinx_mako/commands/__init__.py
@@ -1,12 +1,14 @@
 from typing import Type
 
 from ryujinx_mako.commands._subcommand import Subcommand
+from ryujinx_mako.commands.exec_ryujinx_tasks import ExecRyujinxTasks
 from ryujinx_mako.commands.setup_git import SetupGit
 from ryujinx_mako.commands.update_reviewers import UpdateReviewers
 
 SUBCOMMANDS: list[Type[Subcommand]] = [
     SetupGit,
     UpdateReviewers,
+    ExecRyujinxTasks,
 ]
 
 __all__ = SUBCOMMANDS

--- a/ryujinx_mako/commands/_subcommand.py
+++ b/ryujinx_mako/commands/_subcommand.py
@@ -6,7 +6,8 @@ from typing import Any
 from github import Github
 from github.Auth import AppAuth
 
-from ryujinx_mako._const import APP_ID, PRIVATE_KEY, INSTALLATION_ID, SCRIPT_NAME
+from ryujinx_mako._const import APP_ID, PRIVATE_KEY, INSTALLATION_ID, SCRIPT_NAME, \
+    IS_DRY_RUN
 
 
 class Subcommand(ABC):
@@ -50,7 +51,7 @@ class Subcommand(ABC):
 class GithubSubcommand(Subcommand, ABC):
     _github = Github(
         auth=AppAuth(APP_ID, PRIVATE_KEY).get_installation_auth(INSTALLATION_ID)
-    )
+    ) if not IS_DRY_RUN else None
 
     @property
     def github(self):

--- a/ryujinx_mako/commands/_subcommand.py
+++ b/ryujinx_mako/commands/_subcommand.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser, Namespace
+from typing import Any
 
 from github import Github
 from github.Auth import AppAuth
@@ -9,6 +10,8 @@ from ryujinx_mako._const import APP_ID, PRIVATE_KEY, INSTALLATION_ID, SCRIPT_NAM
 
 
 class Subcommand(ABC):
+    _subcommands: dict[str, Any] = {}
+
     @abstractmethod
     def __init__(self, parser: ArgumentParser):
         parser.set_defaults(func=self.run)
@@ -32,6 +35,16 @@ class Subcommand(ABC):
     @abstractmethod
     def description() -> str:
         raise NotImplementedError()
+
+    @classmethod
+    def get_subcommand(cls, name: str):
+        return cls._subcommands[name]
+
+    @classmethod
+    def add_subcommand(cls, name: str, subcommand):
+        if name in cls._subcommands.keys():
+            raise ValueError(f"Key '{name}' already exists in {cls}._subcommands")
+        cls._subcommands[name] = subcommand
 
 
 class GithubSubcommand(Subcommand, ABC):

--- a/ryujinx_mako/commands/_subcommand.py
+++ b/ryujinx_mako/commands/_subcommand.py
@@ -6,8 +6,13 @@ from typing import Any
 from github import Github
 from github.Auth import AppAuth
 
-from ryujinx_mako._const import APP_ID, PRIVATE_KEY, INSTALLATION_ID, SCRIPT_NAME, \
-    IS_DRY_RUN
+from ryujinx_mako._const import (
+    APP_ID,
+    PRIVATE_KEY,
+    INSTALLATION_ID,
+    SCRIPT_NAME,
+    IS_DRY_RUN,
+)
 
 
 class Subcommand(ABC):
@@ -49,9 +54,11 @@ class Subcommand(ABC):
 
 
 class GithubSubcommand(Subcommand, ABC):
-    _github = Github(
-        auth=AppAuth(APP_ID, PRIVATE_KEY).get_installation_auth(INSTALLATION_ID)
-    ) if not IS_DRY_RUN else None
+    _github = (
+        Github(auth=AppAuth(APP_ID, PRIVATE_KEY).get_installation_auth(INSTALLATION_ID))
+        if not IS_DRY_RUN
+        else None
+    )
 
     @property
     def github(self):

--- a/ryujinx_mako/commands/exec_ryujinx_tasks.py
+++ b/ryujinx_mako/commands/exec_ryujinx_tasks.py
@@ -51,13 +51,11 @@ class ExecRyujinxTasks(GithubSubcommand):
         parser.add_argument(
             "repo_path",
             type=str,
-            required=True,
             help="full name of the GitHub repository (format: OWNER/REPO)",
         )
         parser.add_argument(
             "run_id",
             type=int,
-            required=True,
             help="The unique identifier of the workflow run",
         )
         super().__init__(parser)

--- a/ryujinx_mako/commands/exec_ryujinx_tasks.py
+++ b/ryujinx_mako/commands/exec_ryujinx_tasks.py
@@ -1,0 +1,88 @@
+import json
+import os
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Any
+
+from github.Repository import Repository
+from github.WorkflowRun import WorkflowRun
+
+from ryujinx_mako.commands._subcommand import GithubSubcommand
+
+
+class ExecRyujinxTasks(GithubSubcommand):
+    @staticmethod
+    def name() -> str:
+        return "exec-ryujinx-tasks"
+
+    @staticmethod
+    def description() -> str:
+        return "Execute all Ryujinx tasks for a specific event"
+
+    # noinspection PyTypeChecker
+    def __init__(self, parser: ArgumentParser):
+        self._workspace: Path = None
+        self._repo: Repository = None
+        self._workflow_run: WorkflowRun = None
+        self._event: dict[str, Any] = None
+        self._event_name: str = None
+
+        parser.add_argument(
+            "--event-name",
+            type=str,
+            required=True,
+            help="The name of the event that triggered the workflow run.",
+        )
+        parser.add_argument(
+            "--event-path",
+            type=str,
+            required=True,
+            help="The path to the file on the runner that contains the full "
+                 "event webhook payload.",
+        )
+        parser.add_argument(
+            "-w",
+            "--workspace",
+            type=Path,
+            required=False,
+            default=Path(os.getcwd()),
+            help="The working directory on the runner."
+        )
+        parser.add_argument(
+            "repo_path",
+            type=str,
+            required=True,
+            help="The path to a GitHub repository."
+        )
+        parser.add_argument(
+            "run_id",
+            type=int,
+            required=True,
+            help="The unique identifier of the workflow run.",
+        )
+        super().__init__(parser)
+
+    def update_reviewers(self):
+        # Prepare update-reviewers
+        self.logger.info("Task: update-reviewers")
+        args = Namespace()
+        args.repo_path = self._repo.full_name
+        args.pr_number = self._event["number"]
+        args.config_path = Path(self._workspace, ".github", "reviewers.yml")
+        # Run task
+        self.get_subcommand("update-reviewers").run(args)
+
+    def run(self, args: Namespace):
+        self.logger.info("Executing Ryujinx tasks...")
+
+        self._workspace = args.workspace
+        self._repo = self.github.get_repo(args.repo_path)
+        self._workflow_run = self._repo.get_workflow_run(args.run_id)
+        self._event_name = args.event_name
+        with open(args.event_path, "r") as file:
+            self._event = json.load(file)
+
+        if args.event_name == "pull_request":
+            self.update_reviewers()
+
+        self.logger.info("Finished executing Ryujinx tasks!")

--- a/ryujinx_mako/commands/exec_ryujinx_tasks.py
+++ b/ryujinx_mako/commands/exec_ryujinx_tasks.py
@@ -31,14 +31,14 @@ class ExecRyujinxTasks(GithubSubcommand):
             "--event-name",
             type=str,
             required=True,
-            help="The name of the event that triggered the workflow run.",
+            help="the name of the event that triggered the workflow run",
         )
         parser.add_argument(
             "--event-path",
             type=str,
             required=True,
-            help="The path to the file on the runner that contains the full "
-                 "event webhook payload.",
+            help="the path to the file on the runner that contains the full "
+                 "event webhook payload",
         )
         parser.add_argument(
             "-w",
@@ -46,19 +46,19 @@ class ExecRyujinxTasks(GithubSubcommand):
             type=Path,
             required=False,
             default=Path(os.getcwd()),
-            help="The working directory on the runner."
+            help="the working directory on the runner"
         )
         parser.add_argument(
             "repo_path",
             type=str,
             required=True,
-            help="The path to a GitHub repository."
+            help="full name of the GitHub repository (format: OWNER/REPO)",
         )
         parser.add_argument(
             "run_id",
             type=int,
             required=True,
-            help="The unique identifier of the workflow run.",
+            help="The unique identifier of the workflow run",
         )
         super().__init__(parser)
 

--- a/ryujinx_mako/commands/exec_ryujinx_tasks.py
+++ b/ryujinx_mako/commands/exec_ryujinx_tasks.py
@@ -80,7 +80,7 @@ class ExecRyujinxTasks(GithubSubcommand):
         with open(args.event_path, "r") as file:
             self._event = json.load(file)
 
-        if args.event_name == "pull_request":
+        if args.event_name == "pull_request_target":
             self.update_reviewers()
 
         self.logger.info("Finished executing Ryujinx tasks!")

--- a/ryujinx_mako/commands/exec_ryujinx_tasks.py
+++ b/ryujinx_mako/commands/exec_ryujinx_tasks.py
@@ -38,7 +38,7 @@ class ExecRyujinxTasks(GithubSubcommand):
             type=str,
             required=True,
             help="the path to the file on the runner that contains the full "
-                 "event webhook payload",
+            "event webhook payload",
         )
         parser.add_argument(
             "-w",
@@ -46,7 +46,7 @@ class ExecRyujinxTasks(GithubSubcommand):
             type=Path,
             required=False,
             default=Path(os.getcwd()),
-            help="the working directory on the runner"
+            help="the working directory on the runner",
         )
         parser.add_argument(
             "repo_path",

--- a/ryujinx_mako/commands/setup_git.py
+++ b/ryujinx_mako/commands/setup_git.py
@@ -12,14 +12,14 @@ class SetupGit(GithubSubcommand):
 
     @staticmethod
     def description() -> str:
-        return f"Set git identity to {NAME}"
+        return f"Configure git identity for {NAME}"
 
     def __init__(self, parser: ArgumentParser):
         parser.add_argument(
             "-l",
             "--local",
             action="store_true",
-            help="Set git identity only for the current repository.",
+            help="configure the git identity only for the current repository",
         )
         super().__init__(parser)
 

--- a/ryujinx_mako/commands/setup_git.py
+++ b/ryujinx_mako/commands/setup_git.py
@@ -29,7 +29,7 @@ class SetupGit(GithubSubcommand):
 
         self.logger.debug(f"Getting GitHub user for: {gh_username}")
         user = self.github.get_user(gh_username)
-        email = GH_EMAIL_TEMPLATE.format(user_id=user.id, username=user.name)
+        email = GH_EMAIL_TEMPLATE.format(user_id=user.id, username=user.login)
 
         if args.local:
             self.logger.debug("Setting git identity for local repo...")
@@ -37,7 +37,7 @@ class SetupGit(GithubSubcommand):
             self.logger.debug("Setting git identity globally...")
             base_command.append("--global")
 
-        config = {"user.name": user.name, "user.email": email}
+        config = {"user.name": user.login, "user.email": email}
         for option, value in config.items():
             self.logger.info(f"Setting git {option} to: {value}")
             command = base_command.copy()

--- a/ryujinx_mako/commands/update_reviewers.py
+++ b/ryujinx_mako/commands/update_reviewers.py
@@ -27,9 +27,7 @@ class UpdateReviewers(GithubSubcommand):
             help="full name of the GitHub repository (format: OWNER/REPO)",
         )
         parser.add_argument(
-            "pr_number",
-            type=int,
-            help="the number of the pull request to check"
+            "pr_number", type=int, help="the number of the pull request to check"
         )
         parser.add_argument(
             "config_path",

--- a/ryujinx_mako/commands/update_reviewers.py
+++ b/ryujinx_mako/commands/update_reviewers.py
@@ -21,9 +21,21 @@ class UpdateReviewers(GithubSubcommand):
         self._reviewers = set()
         self._team_reviewers = set()
 
-        parser.add_argument("repo_path", type=str)
-        parser.add_argument("pr_number", type=int)
-        parser.add_argument("config_path", type=Path)
+        parser.add_argument(
+            "repo_path",
+            type=str,
+            help="full name of the GitHub repository (format: OWNER/REPO)",
+        )
+        parser.add_argument(
+            "pr_number",
+            type=int,
+            help="the number of the pull request to check"
+        )
+        parser.add_argument(
+            "config_path",
+            type=Path,
+            help="the path to the reviewers config file",
+        )
 
         super().__init__(parser)
 

--- a/tools/generate_help.py
+++ b/tools/generate_help.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+from typing import Union
+
+
+def run_mako_command(command: Union[str, list[str]]) -> str:
+    subprocess_cmd = ["poetry", "run", "ryujinx-mako"]
+
+    if isinstance(command, str):
+        subprocess_cmd.append(command)
+    elif isinstance(command, list):
+        subprocess_cmd.extend(command)
+    else:
+        raise TypeError(command)
+
+    env = os.environ.copy()
+    env["MAKO_DRY_RUN"] = "1"
+
+    process = subprocess.run(
+        subprocess_cmd, stdout=subprocess.PIPE, check=True, env=env
+    )
+
+    return process.stdout.decode()
+
+
+def print_help(name: str, output: str, level=3):
+    headline_prefix = "#" * level
+    print(f"{headline_prefix} {name}\n")
+    print("```")
+    print(output.rstrip())
+    print("```\n")
+
+
+general_help = run_mako_command("--help")
+for line in general_help.splitlines():
+    subcommands = re.match(r" {2}\{(.+)}", line)
+    if subcommands:
+        break
+else:
+    subcommands = None
+
+if not subcommands:
+    print("Could not find subcommands in general help output:")
+    print(general_help)
+    exit(1)
+
+subcommands = subcommands.group(1).split(",")
+
+print_help("Available commands", general_help, 2)
+for subcommand in subcommands:
+    print_help(subcommand, run_mako_command([subcommand, "--help"]))


### PR DESCRIPTION
This PR aims to make Mako easier to use and adds a command to handle all Ryujinx specific tasks that Mako might want to help with in our projects.

Let me try to summarize the changes:

- All Mako actions now properly keep track of the path to this repository.
- The previous `setup-mako` action was improved to ensure python and poetry are available.
- A new `execute-command` action allows to easily execute Mako subcommands without manually invoking `poetry run`
- A new `Ryujinx-Mako` (repository) action combines the previous two actions and only executes the setup action if the environment hasn't been set up yet.
  Mako users should only use this action from now on.
- A new command `exec-ryujinx-tasks` was added, so we are able to run multiple tasks without modifying the workflow in our other repositories.
  Currently this will only execute the `update-reviewers` command, but I already have some ideas on what to add next.

Aside from that a new script `generate_help.py` was added so we can easily update the `README.md` if new commands get added or existing ones modified/removed.

I'll mark this PR as ready for review when I created the PR for Ryujinx as well, since these are breaking changes.